### PR TITLE
MSOF-249 trim trailing slash from Acrolinx Server URL

### DIFF
--- a/Acrolinx.Net/Acrolinx.Net.Tests/Acrolinx.Net.Tests.csproj
+++ b/Acrolinx.Net/Acrolinx.Net.Tests/Acrolinx.Net.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -6,9 +6,12 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <UserSecretsId>1f82b9ab-768e-480a-b6c2-00a49c918c7b</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />

--- a/Acrolinx.Net/Acrolinx.Net.Tests/EndpointTest.cs
+++ b/Acrolinx.Net/Acrolinx.Net.Tests/EndpointTest.cs
@@ -23,21 +23,25 @@ using Moq;
 namespace Acrolinx.Net.Tests
 {
     [TestClass]
-    public class EndpointTest
+    public class EndpointTest : TestBase
     {
         private AcrolinxEndpoint endpoint = null;
+
+        [TestInitialize] // Runs before each test
+        public void Init()
+        {
+            endpoint = TestEnvironment.CreateEndpoint();
+        }
 
         [TestMethod]
         public void TestCreate()
         {
-            CreateEndpoint();
             Assert.IsNotNull(endpoint);
         }
 
         [TestMethod]
         public async Task TestSso()
         {
-            CreateEndpoint();
             var accessToken = await GetAccessToken();
 
             Assert.IsNotNull(accessToken);
@@ -52,7 +56,6 @@ namespace Acrolinx.Net.Tests
         [TestMethod]
         public async Task TestSsoFailDueToWrongToken()
         {
-            CreateEndpoint();
             try
             {
                 await endpoint.SignInWithSSO("something", TestEnvironment.Username);
@@ -69,7 +72,6 @@ namespace Acrolinx.Net.Tests
         [TestMethod]
         public async Task TestSsoFailDueToMissingMetadata()
         {
-            CreateEndpoint();
             try
             {
                 await endpoint.SignInWithSSO(TestEnvironment.SsoToken, TestEnvironment.Username + "_without_metadata");
@@ -86,7 +88,6 @@ namespace Acrolinx.Net.Tests
         [Timeout(3000)]
         public void TestSignInInteractiveHasPollUrl()
         {
-            CreateEndpoint();
             var openUrlMock = new Mock<AcrolinxEndpoint.OpenUrl>();
             var signIn = endpoint.SignInInteractive(openUrlMock.Object);
             Thread.Sleep(2000);
@@ -98,7 +99,6 @@ namespace Acrolinx.Net.Tests
         [ExpectedException(typeof(SignInFailedException), "Timeout")]
         public async Task TestSignInInteractiveTimeout()
         {
-            CreateEndpoint();
             await endpoint.SignInInteractive((url) => { }, new TimeSpan(0, 0, 1), null);
         }
 
@@ -107,7 +107,6 @@ namespace Acrolinx.Net.Tests
         [Ignore]
         public async Task ManualTestSignInInteractive()
         {
-            CreateEndpoint();
             AccessToken accessToken = await endpoint.SignInInteractive((url) =>
             {
                 System.Diagnostics.Trace.WriteLine("Sign in manually in browser please: " + url);
@@ -121,7 +120,6 @@ namespace Acrolinx.Net.Tests
         [TestMethod]
         public async Task TestSubmitCheck()
         {
-            CreateEndpoint();
             var accessToken = await GetAccessToken();
 
             var checkRequest = new CheckRequest()
@@ -143,7 +141,6 @@ namespace Acrolinx.Net.Tests
         [Timeout(4 * 1000)]
         public async Task TestSignInInteractiveWithTokenUsesTokenWithoutUserInteraction()
         {
-            CreateEndpoint();
             var accessToken = await GetAccessToken();
 
             bool interactiveCalled = false;
@@ -157,7 +154,6 @@ namespace Acrolinx.Net.Tests
         [Timeout(10 * 1000)]
         public async Task TestSignInInteractiveWithInvalidTokenFallsBackToInteractive()
         {
-            CreateEndpoint();
             var accessToken = new AccessToken("invalid");
 
             bool interactiveCalled = false;
@@ -177,8 +173,6 @@ namespace Acrolinx.Net.Tests
         [Timeout(10 * 1000)]
         public async Task TestSignInInteractiveWithInvalidTokenFallsBackToInteractive2()
         {
-            CreateEndpoint();
-
             bool interactiveCalled = false;
             try
             {
@@ -195,7 +189,6 @@ namespace Acrolinx.Net.Tests
         [TestMethod]
         public async Task TestPoll()
         {
-            CreateEndpoint();
             var accessToken = await GetAccessToken();
 
             var checkResponse = await SubmitCheck(accessToken, new CheckRequest()
@@ -218,7 +211,6 @@ namespace Acrolinx.Net.Tests
         [TestMethod]
         public async Task TestCheckResponse()
         {
-            CreateEndpoint();
             var accessToken = await GetAccessToken();
 
             var checkResponse = await SubmitCheck(accessToken, new CheckRequest()
@@ -248,7 +240,6 @@ namespace Acrolinx.Net.Tests
         [TestMethod]
         public async Task TestContentAnalysis()
         {
-            CreateEndpoint();
             var accessToken = await GetAccessToken();
 
             var batchId = BatchCheckIdGenerator.GenerateId("NetSDKTest");
@@ -260,7 +251,6 @@ namespace Acrolinx.Net.Tests
         [TestMethod]
         public async Task TestGetCapabilities()
         {
-            CreateEndpoint();
             var accessToken = await GetAccessToken();
             var result = await endpoint.GetCapabilities(accessToken);
             Assert.IsNotNull(result);
@@ -270,7 +260,6 @@ namespace Acrolinx.Net.Tests
         [TestMethod]
         public async Task TestCheckResultIssues()
         {
-            CreateEndpoint();
             var accessToken = await GetAccessToken();
 
             var checkResponse = await SubmitCheck(accessToken, new CheckRequest()
@@ -301,12 +290,5 @@ namespace Acrolinx.Net.Tests
         {
             return await endpoint.SubmitCheck(accessToken, checkRequest);
         }
-
-        private void CreateEndpoint()
-        {
-            endpoint = TestEnvironment.CreateEndpoint();
-        }
-
-
     }
 }

--- a/Acrolinx.Net/Acrolinx.Net.Tests/EndpointTest.cs
+++ b/Acrolinx.Net/Acrolinx.Net.Tests/EndpointTest.cs
@@ -283,7 +283,31 @@ namespace Acrolinx.Net.Tests
             Assert.IsNotNull(checkResult.Issues[0].GuidanceHtml);
             Assert.IsNotNull(checkResult.Issues[0].GoalId);
             Assert.IsNotNull(checkResult.Issues[0].Suggestions);
+        }
 
+        [TestMethod]
+        public async Task TestGetAccessToken_WithEndpointUrlVariations()
+        {
+            var acrolinxEndpointUrl = TestEnvironment.AcrolinxUrl;
+            var urlVariations = new List<string>
+            {
+                acrolinxEndpointUrl.TrimEnd('/'),
+                acrolinxEndpointUrl.TrimEnd('/') + "/",
+                acrolinxEndpointUrl.TrimEnd('/') + "//"
+            };
+
+            Assert.IsTrue(urlVariations.Count == 3);
+            Assert.IsFalse(urlVariations[0].EndsWith("/"));
+            Assert.IsTrue(urlVariations[1].EndsWith("/"));
+            Assert.IsTrue(urlVariations[2].EndsWith("//"));
+
+            foreach (var url in urlVariations)
+            {
+                var endpoint = new AcrolinxEndpoint(url, TestEnvironment.Signature);
+                var accessToken = await endpoint.SignInWithSSO(TestEnvironment.SsoToken, TestEnvironment.Username);
+
+                Assert.IsNotNull(accessToken);
+            }
         }
 
         private async Task<CheckResponse> SubmitCheck(AccessToken accessToken, CheckRequest checkRequest)

--- a/Acrolinx.Net/Acrolinx.Net.Tests/TestBase.cs
+++ b/Acrolinx.Net/Acrolinx.Net.Tests/TestBase.cs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-present Acrolinx GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
 using Acrolinx.Net.Tests;
 using Microsoft.Extensions.Configuration;
 

--- a/Acrolinx.Net/Acrolinx.Net.Tests/TestBase.cs
+++ b/Acrolinx.Net/Acrolinx.Net.Tests/TestBase.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-present Acrolinx GmbH
+ * Copyright 2025-present Acrolinx GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 using Acrolinx.Net.Tests;
 using Microsoft.Extensions.Configuration;
 

--- a/Acrolinx.Net/Acrolinx.Net.Tests/TestBase.cs
+++ b/Acrolinx.Net/Acrolinx.Net.Tests/TestBase.cs
@@ -1,0 +1,25 @@
+using Acrolinx.Net.Tests;
+using Microsoft.Extensions.Configuration;
+
+public class TestBase
+{
+    public static TestEnvironment TestEnvironment { get; set; }
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var builder = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddUserSecrets<TestBase>()
+            .AddEnvironmentVariables();
+
+        var configuration = builder.Build();
+
+        var url = configuration["ACROLINX_API_URL"];
+        var token = configuration["ACROLINX_API_SSO_TOKEN"];
+        var signature = configuration["ACROLINX_DEV_SIGNATURE"];
+        var username = configuration["ACROLINX_API_USERNAME"];
+
+        TestEnvironment = new TestEnvironment(signature, url, username, token);
+    }
+}

--- a/Acrolinx.Net/Acrolinx.Net.Tests/TestEnvironment.cs
+++ b/Acrolinx.Net/Acrolinx.Net.Tests/TestEnvironment.cs
@@ -38,6 +38,18 @@ namespace Acrolinx.Net.Tests
             return new AcrolinxEndpoint(AcrolinxUrl, _signature);
         }
 
+        public string Signature
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(_signature))
+                {
+                    Trace.WriteLine("Set the Acrolinx signature");
+                }
+                return _signature;
+            }
+        }
+
         public string SsoToken
         {
             get
@@ -57,7 +69,7 @@ namespace Acrolinx.Net.Tests
             {
                 if (string.IsNullOrWhiteSpace(_acrolinxUrl))
                 {
-                    Trace.WriteLine("Set the acrolinx url");
+                    Trace.WriteLine("Set the Acrolinx url");
                 }
                 return _acrolinxUrl;
             }
@@ -69,7 +81,7 @@ namespace Acrolinx.Net.Tests
             {
                 if (string.IsNullOrWhiteSpace(_username))
                 {
-                    Trace.WriteLine("Set the acrolinx use name");
+                    Trace.WriteLine("Set the Acrolinx username");
                 }
                 return _username;
             }

--- a/Acrolinx.Net/Acrolinx.Net.Tests/TestEnvironment.cs
+++ b/Acrolinx.Net/Acrolinx.Net.Tests/TestEnvironment.cs
@@ -18,58 +18,60 @@ using System.Diagnostics;
 
 namespace Acrolinx.Net.Tests
 {
-    class TestEnvironment
+    public class TestEnvironment
     {
-        public static AcrolinxEndpoint CreateEndpoint()
-        {
-            var signature = Environment.GetEnvironmentVariable("ACROLINX_DEV_SIGNATURE");
-            if (signature == null)
-            {
-                // If you don't have signature contant acrolinx
-                Trace.WriteLine("Set the acrolinx client signature");
-            }
+        private readonly string _signature;
+        private readonly string _acrolinxUrl;
+        private readonly string _username;
+        private readonly string _ssoToken;
 
-            return new AcrolinxEndpoint(AcrolinxUrl, signature);
+        public TestEnvironment(string signature, string acrolinxUrl, string username, string ssoToken)
+        {
+            _signature = signature;
+            _acrolinxUrl = acrolinxUrl;
+            _username = username;
+            _ssoToken = ssoToken;
         }
 
-        public static string SsoToken
+        public AcrolinxEndpoint CreateEndpoint()
+        {
+            return new AcrolinxEndpoint(AcrolinxUrl, _signature);
+        }
+
+        public string SsoToken
         {
             get
             {
-                var token = Environment.GetEnvironmentVariable("ACROLINX_API_SSO_TOKEN");
-
-                if (token == null)
+                if (_ssoToken == null)
                 {
                     Trace.WriteLine("Set the SSO token");
                 }
 
-                return token;
+                return _ssoToken;
             }
         }
 
-        public static string AcrolinxUrl
+        public string AcrolinxUrl
         {
             get
             {
-                var url = Environment.GetEnvironmentVariable("ACROLINX_API_URL");
-                if (string.IsNullOrWhiteSpace(url))
-                { 
+                if (string.IsNullOrWhiteSpace(_acrolinxUrl))
+                {
                     Trace.WriteLine("Set the acrolinx url");
                 }
-                return url;
+                return _acrolinxUrl;
             }
         }
 
-        public static string Username
+        public string Username
         {
             get
             {
-                var username = Environment.GetEnvironmentVariable("ACROLINX_API_USERNAME");
-                if (string.IsNullOrWhiteSpace(username))
+                if (string.IsNullOrWhiteSpace(_username))
                 {
                     Trace.WriteLine("Set the acrolinx use name");
                 }
-                return username;
+                return _username;
             }
         }
     }

--- a/Acrolinx.Net/Acrolinx.Net/AcrolinxEndpoint.cs
+++ b/Acrolinx.Net/Acrolinx.Net/AcrolinxEndpoint.cs
@@ -107,7 +107,8 @@ namespace Acrolinx.Net
             {
                 return apiPath;
             }
-            return acrolinxUrl + "/api/v1/" + apiPath;
+
+            return acrolinxUrl.TrimEnd('/') + "/api/v1/" + apiPath;
         }
 
         private static void AddExtraHeader(Dictionary<string, string> extraHeaders, HttpRequestMessage request)


### PR DESCRIPTION
- Trim trailing slash from Acrolinx Server URL to ensure building a valid request URL
- Add support for dotnet user secrets
- Add TestBase class to simplify creation of AcrolinxEndpoint