### PR TITLE
Remove deprecated reviewers Dependabot config option

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,20 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - abhijeetnarvekar
-      - mscc-sascha
   - package-ecosystem: "nuget"
     directory: "/Acrolinx.Net/Acrolinx.Net/"
     schedule:
       interval: "daily"
-    reviewers:
-      - abhijeetnarvekar
-      - mscc-sascha
   - package-ecosystem: "nuget"
     directory: "/Acrolinx.Net/Acrolinx.Net.Tests/"
     schedule:
       interval: "daily"
-    reviewers:
-      - abhijeetnarvekar
-      - mscc-sascha


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/